### PR TITLE
Update reflect-metadata version range.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
       "peerDependencies": {
         "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
         "@nestjs/graphql": "^10.0.0 || ^11.0.0 || ^12.0.0",
-        "reflect-metadata": "^0.1.14"
+        "reflect-metadata": "^0.1.0 || ^0.2.0"
       }
     },
     "node_modules/@graphql-tools/merge": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "peerDependencies": {
     "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
     "@nestjs/graphql": "^10.0.0 || ^11.0.0 || ^12.0.0",
-    "reflect-metadata": "^0.1.14"
+    "reflect-metadata": "^0.1.0 || ^0.2.0"
   },
   "devDependencies": {
     "@types/node": "^20.3.1",


### PR DESCRIPTION
This is to accommodate both the 0.1.x and 0.2.x versions of "reflect-metadata", hence providing compatibility with more versions.